### PR TITLE
Track nick changes by parting and joining a new user

### DIFF
--- a/lib/irc/IrcEventBroker.js
+++ b/lib/irc/IrcEventBroker.js
@@ -347,6 +347,22 @@ IrcEventBroker.prototype.addHooks = function(client, connInst) {
             req, server, createUser(nick), chan, "join"
         ));
     });
+    this._hookIfClaimed(client, connInst, "nick", function(oldNick, newNick, chans, msg) {
+        chans = chans || [];
+        chans.forEach(function(chan) {
+            var req = createRequest();
+            complete(req, ircHandler.onMessage(
+                req, server, createUser(oldNick), chan,
+                new IrcAction("emote", "is now known as " + newNick)
+            ));
+            complete(req, ircHandler.onPart(
+                req, server, createUser(oldNick), chan, "nick"
+            ));
+            complete(req, ircHandler.onJoin(
+                req, server, createUser(newNick), chan, "nick"
+            ));
+        });
+    });
     // bucket names and drain them one at a time to avoid flooding
     // the matrix side with registrations / joins
     var namesBucket = [


### PR DESCRIPTION
The only way to track nick changes on the IRC side at the moment is
to let the user leave the channel and letting a new user with the new
nick join. This looks weird but still is better than many zombie
nicks and hidden users in bridged channels.

Fixes: #71